### PR TITLE
fix: skip close if no file was passed

### DIFF
--- a/scripts/urdf2mjcf
+++ b/scripts/urdf2mjcf
@@ -73,8 +73,11 @@ Parse a URDF model into MJCF format""",
 
     args.urdf.close()
     args.mjcf.close()
-    args.mujoco_node.close()
-    args.sensor_config.close()
+
+    if args.mujoco_node is not None:
+        args.mujoco_node.close()
+    if args.sensor_config is not None:
+        args.sensor_config.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Attempting to close the mujoco_node and sensor_config file objects if no
files were passed resulted in an error. The attempt is now skipped
should no files have been given.