### PR TITLE
feat: adds ROS node version of urdf2mjcf script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,6 @@ catkin_install_python(
   PROGRAMS
   scripts/urdf2mjcf
   scripts/rd2urdf
+  scripts/urdf2mjcf_ros
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/scripts/urdf2mjcf_ros
+++ b/scripts/urdf2mjcf_ros
@@ -1,0 +1,38 @@
+#! python3
+
+from time import time
+import rospy
+from sys import stdin, stdout
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter, FileType
+from pathlib import Path
+
+from defusedxml.ElementTree import fromstring
+
+import urdf2mjcf.core as u2m
+
+
+class ArgFormatter(ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter):
+    pass
+
+if __name__ == "__main__":
+    rospy.init_node('urdf2mjcf')
+
+    urdf_path = rospy.get_param('urdf_source', 'robot_description')
+    xml_destination = rospy.get_param('xml_destination', 'mujoco_xml')
+
+    while not rospy.has_param(urdf_path) and not rospy.is_shutdown():
+        time.sleep(0.1)
+
+    urdf = rospy.get_param(urdf_path)
+    sensor_config = rospy.get_param('sensor_config', None)
+    mujoco_node = rospy.get_param('mujoco_node', None)
+
+    element = fromstring(urdf)
+
+    result = u2m.full_pipeline(
+        fromstring(urdf),
+        sensor_config=u2m._parse_element(sensor_config),
+        mujoco_node=u2m._parse_element(mujoco_node),
+    )
+
+    rospy.set_param(xml_destination, u2m.tostring(result, encoding="unicode"))


### PR DESCRIPTION
This PR adds a ROS node version of the  `urdf2mjcf` script, which can be parameterized directly by ROS.

The input URDF path and the rosparam path where the mjcf output is saved can be set by providing ROS parameters for `urdf_source` and `xml_destination`. If not provided, the defaults 'robot_description' and 'mujoco_xml' are used.
The node waits until the source URDF is available at the configured path, processes the URDF and uploads the resulting XML to the configured destination. Note, that components relying on the XML should implement a similar waiting mechanism to ensure the XML is processed once it becomes available.

Below is a minimal roslaunch example:

```xml
<?xml version="1.0"?>
<launch>

    <!-- load urdf into rosparam path 'robot_description' -->

    <node name="urdf2mjcf_converter" pkg="urdf2mjcf" type="urdf2mjcf_ros" >
      <param name="urdf_source" value='robot_description' />
      <param name="xml_destination" value='mujoco_xml' />
    </node>

    <!-- start mujoco_ros node which expects rosparam path 'mujoco_xml' to be set -->

</launch>
```