### PR TITLE
Feature | Default Ground Plane and Lighting in MJCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,36 @@
-## Upcoming 1.2.2<a name="1.2.2"></a> (2022-11-28)
+## Upcoming 2.0.0<a name="2.0.0"></a> (2022-11-28)
+
+### Bug Fixes
+
+- **default_lighting:** make attributes optional ([30f55fe](https://github.com/balandbal/urdf2mjcf/commit/30f55fe4accb16ab1a713cdc26ddce3666dfc611))
 
 ### Build
 
 - remove irrelevant pytest dependency ([75ba99a](https://github.com/balandbal/urdf2mjcf/commit/75ba99abc46e7fa4329be1d4273a11702fe0de1e))
 
+### Chore
+
+- **roslaunch:** extend with ground and lighting ([4af0801](https://github.com/balandbal/urdf2mjcf/commit/4af0801a264502bf448c7265fcadfc54a23ca427))
+
+### Code Refactoring
+
+- **core:** move full_pipeline into module app ([965f523](https://github.com/balandbal/urdf2mjcf/commit/965f523183373921fe2339331f41f5e9440f6c94))
+
 ### Docs
 
 - **changelog:** add template and generation info ([0085b0e](https://github.com/balandbal/urdf2mjcf/commit/0085b0e89cd6742d67d6aa9c7fa8f2222bbcefce))
+
+### Features
+
+- **app:** integrate default ground and lighting ([ce78d85](https://github.com/balandbal/urdf2mjcf/commit/ce78d85a9c6acc310ece3ab98e1fe3c8dcf2e7b9))
+- **cli:** expose default ground and lighting ([6d420e5](https://github.com/balandbal/urdf2mjcf/commit/6d420e59e70ded66a1bdae6018ffd767042e7374))
+- **rosnode:** expose default ground and lighting ([626c950](https://github.com/balandbal/urdf2mjcf/commit/626c950acf2c7fb8e34693e396f6887254f2a419))
+- add postprocess function to add ground plane ([32cc9a0](https://github.com/balandbal/urdf2mjcf/commit/32cc9a0b777dfd25d567d1b2c841b4932239b483))
+- add postprocess function to add lighting ([45b9801](https://github.com/balandbal/urdf2mjcf/commit/45b98012ab298b7e3c5e33abe2e1dd44ab84e1ca))
+
+### Style
+
+- **roslaunch:** harmonize quotation marks ([d11f3e7](https://github.com/balandbal/urdf2mjcf/commit/d11f3e7507cd807f436e0ad96a1edde9d7558f29))
 
 ### Tests
 

--- a/launch/urdf2mjcf_converter.launch
+++ b/launch/urdf2mjcf_converter.launch
@@ -6,6 +6,8 @@
     <node name="urdf2mjcf_converter" pkg="urdf2mjcf" type="urdf2mjcf_ros">
         <param name="urdf_source" value="robot_description" />
         <param name="xml_destination" value="mujoco_xml" />
+        <param name="add_ground" value="false" />
+        <param name="add_lighting" value="false" />
     </node>
 
     <!-- start mujoco_ros node which expects rosparam path 'mujoco_xml' to be set -->

--- a/launch/urdf2mjcf_converter.launch
+++ b/launch/urdf2mjcf_converter.launch
@@ -4,8 +4,8 @@
     <!-- load urdf into rosparam path 'robot_description' -->
 
     <node name="urdf2mjcf_converter" pkg="urdf2mjcf" type="urdf2mjcf_ros">
-        <param name="urdf_source" value='robot_description' />
-        <param name="xml_destination" value='mujoco_xml' />
+        <param name="urdf_source" value="robot_description" />
+        <param name="xml_destination" value="mujoco_xml" />
     </node>
 
     <!-- start mujoco_ros node which expects rosparam path 'mujoco_xml' to be set -->

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>urdf2mjcf</name>
-  <version>1.2.2</version>
+  <version>2.0.0</version>
   <description>The urdf2mjcf package</description>
 
   <maintainer email="balazs.andras.balint@ipa.fraunhofer.de">Balázs Bálint</maintainer>

--- a/scripts/urdf2mjcf
+++ b/scripts/urdf2mjcf
@@ -4,7 +4,8 @@ from pathlib import Path
 
 from urdf2mjcf import __version__
 from urdf2mjcf.cli import cli
-from urdf2mjcf.core import _parse_element as parse_stream, tostring, full_pipeline
+from urdf2mjcf.app import full_pipeline
+from urdf2mjcf.core import _parse_element as parse_stream, tostring
 
 
 def app(args):

--- a/scripts/urdf2mjcf
+++ b/scripts/urdf2mjcf
@@ -14,6 +14,8 @@ def app(args):
         parse_stream(args.urdf),
         sensor_config=parse_stream(args.sensor_config),
         mujoco_node=parse_stream(args.mujoco_node),
+        default_ground=args.default_ground,
+        default_lighting=args.default_lighting,
     )
 
     args.mjcf.write(tostring(result, encoding="unicode"))

--- a/scripts/urdf2mjcf_ros
+++ b/scripts/urdf2mjcf_ros
@@ -6,7 +6,8 @@ from typing import TypeVar, Union
 from xml.etree.ElementTree import Element
 from defusedxml.ElementTree import fromstring
 
-from urdf2mjcf.core import tostring, full_pipeline
+from urdf2mjcf.app import full_pipeline
+from urdf2mjcf.core import tostring
 
 T = TypeVar("T")
 

--- a/scripts/urdf2mjcf_ros
+++ b/scripts/urdf2mjcf_ros
@@ -32,6 +32,8 @@ if __name__ == "__main__":
 
     urdf_path: str = get_param("urdf_source", "robot_description")  # type: ignore
     xml_destination = get_param("xml_destination", "mujoco_xml")
+    default_ground: str = get_param("add_ground", "false")  # type: ignore
+    default_lighting: str = get_param("add_lighting", "false")  # type: ignore
 
     while not rospy.has_param(urdf_path) and not rospy.is_shutdown():
         sleep(0.1)
@@ -44,6 +46,8 @@ if __name__ == "__main__":
         urdf=fromstring(urdf),
         sensor_config=parse_xml_string(sensor_config),
         mujoco_node=parse_xml_string(mujoco_node),
+        default_ground=True if default_ground.lower() == "true" else False,
+        default_lighting=True if default_lighting.lower() == "true" else False,
     )
 
     rospy.set_param(xml_destination, tostring(result, encoding="unicode"))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(
-    version="1.2.2",
+    version="2.0.0",
     scripts=["scripts/urdf2mjcf", "scripts/rd2urdf"],
     packages=["urdf2mjcf"],
     package_dir={"": "src"},

--- a/src/urdf2mjcf/app.py
+++ b/src/urdf2mjcf/app.py
@@ -1,0 +1,26 @@
+from .core import Element, RosPack
+from .core import (
+    resolve_ros_uris,
+    add_mujoco_node,
+    pass_through_mujoco,
+    populate_sensors,
+)
+
+
+def full_pipeline(
+    urdf: Element,
+    rospack: RosPack = None,
+    sensor_config: Element = None,
+    mujoco_node: Element = None,
+) -> Element:
+    """Convert URDF object to MJCF"""
+    resolve_ros_uris(urdf, rospack)
+    add_mujoco_node(urdf, mujoco_node)
+
+    mjcf = pass_through_mujoco(urdf)
+
+    if sensor_config is not None:
+        populate_sensors(mjcf, sensor_config)
+        mjcf = pass_through_mujoco(mjcf)
+
+    return mjcf

--- a/src/urdf2mjcf/app.py
+++ b/src/urdf2mjcf/app.py
@@ -5,6 +5,8 @@ from .core import (
     pass_through_mujoco,
     populate_sensors,
 )
+from .default_elements.ground import add_ground
+from .default_elements.lighting import add_lighting
 
 
 def full_pipeline(
@@ -12,6 +14,8 @@ def full_pipeline(
     rospack: RosPack = None,
     sensor_config: Element = None,
     mujoco_node: Element = None,
+    default_ground: bool = False,
+    default_lighting: bool = False,
 ) -> Element:
     """Convert URDF object to MJCF"""
     resolve_ros_uris(urdf, rospack)
@@ -22,5 +26,10 @@ def full_pipeline(
     if sensor_config is not None:
         populate_sensors(mjcf, sensor_config)
         mjcf = pass_through_mujoco(mjcf)
+
+    if default_ground:
+        add_ground(mjcf)
+    if default_lighting:
+        add_lighting(mjcf)
 
     return mjcf

--- a/src/urdf2mjcf/cli.py
+++ b/src/urdf2mjcf/cli.py
@@ -53,4 +53,16 @@ Parse a URDF model into MJCF format""",
         default=None,
         help="the XML file defining the global MuJoCo configuration",
     )
+    parser.add_argument(
+        "--ground",
+        dest="default_ground",
+        action="store_true",
+        help="whether to add the default ground plane to the MuJoCo model",
+    )
+    parser.add_argument(
+        "--lighting",
+        dest="default_lighting",
+        action="store_true",
+        help="whether to add the default lighting to the MuJoCo model",
+    )
     return parser

--- a/src/urdf2mjcf/core.py
+++ b/src/urdf2mjcf/core.py
@@ -137,25 +137,6 @@ def populate_sensors(mjcf: Element, sensor_config: Element) -> None:
     mjcf.extend(sensor_config.findall("./sensor"))
 
 
-def full_pipeline(
-    urdf: Element,
-    rospack: RosPack = None,
-    sensor_config: Element = None,
-    mujoco_node: Element = None,
-) -> Element:
-    """Convert URDF object to MJCF"""
-    resolve_ros_uris(urdf, rospack)
-    add_mujoco_node(urdf, mujoco_node)
-
-    mjcf = pass_through_mujoco(urdf)
-
-    if sensor_config is not None:
-        populate_sensors(mjcf, sensor_config)
-        mjcf = pass_through_mujoco(mjcf)
-
-    return mjcf
-
-
 # Copyright (c) 2022 Fraunhofer IPA
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted

--- a/src/urdf2mjcf/default_elements/ground.py
+++ b/src/urdf2mjcf/default_elements/ground.py
@@ -1,0 +1,73 @@
+from typing import Dict
+
+from ..core import Element, SubElement
+from ..utils import _update_with_defaults
+
+
+DEFAULT_GROUND_TEXTURE = {
+    "name": "texplane",
+    "builtin": "checker",
+    "height": "512",
+    "width": "512",
+    "rgb1": ".2 .3 .4",
+    "rgb2": ".1 .15 .2",
+    "type": "2d",
+}
+"""TODO: docstring
+"""
+
+DEFAULT_GROUND_MATERIAL = {
+    "name": "MatPlane",
+    "reflectance": "0.5",
+    "shininess": "0.01",
+    "specular": "0.1",
+    "texrepeat": "1 1",
+    "texture": "texplane",
+    "texuniform": "true",
+}
+"""TODO: docstring
+"""
+
+DEFAULT_GROUND_GEOM = {
+    "name": "ground_plane",
+    "type": "plane",
+    "size": "5 5 10",
+    "material": "MatPlane",
+    "rgba": "1 1 1 1",
+}
+"""TODO: docstring
+"""
+
+
+def add_ground(
+    mjcf: Element,
+    texture_attrib: Dict[str, str] = None,
+    material_attrib: Dict[str, str] = None,
+    geom_attrib: Dict[str, str] = None,
+) -> None:
+    """_summary_
+
+    Parameters
+    ----------
+    mjcf : Element
+        _description_
+    texture_attrib : Dict[str, str], optional
+        _description_, by default None
+    material_attrib : Dict[str, str], optional
+        _description_, by default None
+    geom_attrib : Dict[str, str], optional
+        _description_, by default None
+    """  # TODO: docstring
+    asset = SubElement(mjcf, "asset")
+
+    texture_attrib = _update_with_defaults(DEFAULT_GROUND_TEXTURE, texture_attrib)
+    SubElement(asset, "texture", texture_attrib)
+
+    material_attrib = _update_with_defaults(DEFAULT_GROUND_MATERIAL, material_attrib)
+    SubElement(asset, "material", material_attrib)
+
+    worldbody = mjcf.find("./worldbody")
+    worldbody = SubElement(mjcf, "worldbody") if worldbody is None else worldbody
+
+    geom_attrib = _update_with_defaults(DEFAULT_GROUND_GEOM, geom_attrib)
+    SubElement(worldbody, "geom", geom_attrib)

--- a/src/urdf2mjcf/default_elements/lighting.py
+++ b/src/urdf2mjcf/default_elements/lighting.py
@@ -1,0 +1,28 @@
+from typing import Dict
+
+from ..core import Element, SubElement
+from ..utils import _update_with_defaults
+
+DEFAULT_LIGHT = {
+    "pos": "0 0 1000",
+    "castshadow": "true",
+}
+"""TODO: docstring
+"""
+
+
+def add_lighting(mjcf: Element, light_attrib: Dict[str, str]) -> None:
+    """_summary_
+
+    Parameters
+    ----------
+    mjcf : Element
+        _description_
+    light_attrib : Dict[str, str]
+        _description_
+    """  # TODO: docstring
+    worldbody = mjcf.find("./worldbody")
+    worldbody = SubElement(mjcf, "worldbody") if worldbody is None else worldbody
+
+    light_attrib = _update_with_defaults(DEFAULT_LIGHT, light_attrib)
+    SubElement(worldbody, "light", light_attrib)

--- a/src/urdf2mjcf/default_elements/lighting.py
+++ b/src/urdf2mjcf/default_elements/lighting.py
@@ -11,7 +11,7 @@ DEFAULT_LIGHT = {
 """
 
 
-def add_lighting(mjcf: Element, light_attrib: Dict[str, str]) -> None:
+def add_lighting(mjcf: Element, light_attrib: Dict[str, str] = None) -> None:
     """_summary_
 
     Parameters

--- a/src/urdf2mjcf/utils.py
+++ b/src/urdf2mjcf/utils.py
@@ -1,0 +1,12 @@
+from typing import TypeVar, Dict
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def _update_with_defaults(
+    dictionary: Dict[K, V] = None, defaults: Dict[K, V] = None
+) -> Dict[K, V]:
+    updated_dict = {} if defaults is None else dict(defaults.items())
+    updated_dict.update(dictionary if dictionary is not None else {})
+    return updated_dict

--- a/test/test_urdf2mjcf.py
+++ b/test/test_urdf2mjcf.py
@@ -1,7 +1,8 @@
 import sys
 from pathlib import Path
 
-from urdf2mjcf.core import _parse_element, tostring, full_pipeline as urdf_to_mjcf
+from urdf2mjcf.core import _parse_element, tostring
+from urdf2mjcf.app import full_pipeline as urdf_to_mjcf
 
 _test_dir = Path(__file__).resolve().parent
 sys.path.append(str(_test_dir))


### PR DESCRIPTION
### Bug Fixes

- **default_lighting:** make attributes optional ([30f55fe](https://github.com/balandbal/urdf2mjcf/commit/30f55fe4accb16ab1a713cdc26ddce3666dfc611))

### Build

- remove irrelevant pytest dependency ([75ba99a](https://github.com/balandbal/urdf2mjcf/commit/75ba99abc46e7fa4329be1d4273a11702fe0de1e))

### Chore

- **roslaunch:** extend with ground and lighting ([4af0801](https://github.com/balandbal/urdf2mjcf/commit/4af0801a264502bf448c7265fcadfc54a23ca427))

### Code Refactoring

- **core:** move full_pipeline into module app ([965f523](https://github.com/balandbal/urdf2mjcf/commit/965f523183373921fe2339331f41f5e9440f6c94))

### Docs

- **changelog:** add template and generation info ([0085b0e](https://github.com/balandbal/urdf2mjcf/commit/0085b0e89cd6742d67d6aa9c7fa8f2222bbcefce))

### Features

- **app:** integrate default ground and lighting ([ce78d85](https://github.com/balandbal/urdf2mjcf/commit/ce78d85a9c6acc310ece3ab98e1fe3c8dcf2e7b9))
- **cli:** expose default ground and lighting ([6d420e5](https://github.com/balandbal/urdf2mjcf/commit/6d420e59e70ded66a1bdae6018ffd767042e7374))
- **rosnode:** expose default ground and lighting ([626c950](https://github.com/balandbal/urdf2mjcf/commit/626c950acf2c7fb8e34693e396f6887254f2a419))
- add postprocess function to add ground plane ([32cc9a0](https://github.com/balandbal/urdf2mjcf/commit/32cc9a0b777dfd25d567d1b2c841b4932239b483))
- add postprocess function to add lighting ([45b9801](https://github.com/balandbal/urdf2mjcf/commit/45b98012ab298b7e3c5e33abe2e1dd44ab84e1ca))

### Style

- **roslaunch:** harmonize quotation marks ([d11f3e7](https://github.com/balandbal/urdf2mjcf/commit/d11f3e7507cd807f436e0ad96a1edde9d7558f29))

### Tests

- ensure imports work within the test folder ([6bfb1bf](https://github.com/balandbal/urdf2mjcf/commit/6bfb1bff91fabe5fa0f2ba8ddc0756b78e40e071))
- expose tests to catkin ([49e231a](https://github.com/balandbal/urdf2mjcf/commit/49e231a69c889badc8bc2cd9a074650c3e8e4d6c))
- make ROS URI test more general ([37da775](https://github.com/balandbal/urdf2mjcf/commit/37da77556695ebaa285a0372bd09d1178b5cd028))
- make test assertion more descriptive ([6300f3f](https://github.com/balandbal/urdf2mjcf/commit/6300f3f6a029d5b2d1b8e2bda029f507718fb064))
- remove asset elements from parse tests ([0be5ac9](https://github.com/balandbal/urdf2mjcf/commit/0be5ac9b2da97c7247b14e9b4075e5ae30576231))
